### PR TITLE
Add PR template support to create_feature_pr

### DIFF
--- a/src/types/linear.ts
+++ b/src/types/linear.ts
@@ -1,0 +1,30 @@
+export interface LinearAttachment {
+  id: string;
+  url: string;
+  title?: string;
+  size?: number;
+  contentType?: string;
+  createdAt?: string;
+}
+
+export interface LinearIssue {
+  id: string;
+  title: string;
+  description: string;
+  url: string;
+  status?: string;
+  priority?: number;
+  assignee?: {
+    id: string;
+    name: string;
+    email?: string;
+  };
+  attachments?: LinearAttachment[];
+  labels?: {
+    id: string;
+    name: string;
+    color?: string;
+  }[];
+  createdAt?: string;
+  updatedAt?: string;
+}


### PR DESCRIPTION
## Overview
Adds support for automatically using repository PR templates when creating feature PRs.

## Key Changes
- Added `getPRTemplate` function to fetch PR template from common locations
- Added `formatLinearIssueForPR` to extract info from Linear issues
- Added `fillPRTemplate` to populate template sections
- Updated `createPR` to support PR template and Linear issue integration
- Added TypeScript types for Linear issues and attachments

## Code Highlights
- Fetches PR template from multiple common locations (.github/, docs/, root)
- Extracts key changes from Linear issue bullet points
- Handles attachments/screenshots from Linear issues
- Properly formats PR sections (Overview, Key Changes, Testing, etc.)

## Testing
- [ ] Tested PR template fetching from different locations
- [ ] Tested Linear issue parsing and formatting
- [ ] Verified proper handling of attachments
- [ ] Tested error handling for missing templates

## Links
- [PR Template Documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)